### PR TITLE
Feature/forwarding login identity server

### DIFF
--- a/src/server/middlewares/proxy.ts
+++ b/src/server/middlewares/proxy.ts
@@ -3,14 +3,17 @@ import { createProxyMiddleware } from "http-proxy-middleware";
 import { environment } from "../../loadEnvironments.js";
 import proxyRoutes from "../routers/proxy/proxyRoutes.js";
 
+const { services, apiKey } = environment;
+
 export const registerProxyRoutes = (app: express.Application) => {
   proxyRoutes.forEach((route) => {
     app[route.method](
       route.path,
       createProxyMiddleware({
-        target: environment.services.identityServer,
+        target: services.identityServer,
         pathRewrite: { [route.path]: route.targetPath },
         changeOrigin: true,
+        headers: { "X-API-KEY": apiKey },
       })
     );
   });

--- a/src/server/routers/paths.ts
+++ b/src/server/routers/paths.ts
@@ -1,6 +1,8 @@
 const paths = {
   baseUrl: "/",
   apiDocs: "/api-docs",
+  users: "/users",
+  login: "/login",
 };
 
 export default paths;

--- a/src/server/routers/proxy/proxyRoutes.ts
+++ b/src/server/routers/proxy/proxyRoutes.ts
@@ -1,13 +1,15 @@
 import type { ProxyRoutes } from "./types.js";
 import { environment } from "../../../loadEnvironments.js";
+import paths from "../paths.js";
 
-/* Dejo esta ruta aquí como ejemplo para cuando creéis las rutas */
+const { services } = environment;
+const { login, users } = paths;
 const proxyRoutes: ProxyRoutes = [
   {
-    path: "/dame/llentelmen/tots",
-    method: "get",
-    target: environment.services.identityServer,
-    targetPath: "/gentlemen/",
+    path: `${users}${login}`,
+    method: "post",
+    target: services.identityServer,
+    targetPath: `${users}${login}`,
   },
 ];
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,6 +1,0 @@
-const paths = {
-  users: "/users",
-  login: "/login",
-};
-
-export default paths;


### PR DESCRIPTION
He adaptado el proxyRoute de ejemplo por la de login del identity server. Me falta testear el middleware que aún no me meti con ello.

Entiendo que el path y el target path no necesariamente tienen que ser los mismos, pero me parece más fácil si los frontales hacen la request a gateway con los mismos paths que se lo harían a la API directamente 