### PR TITLE
Fix outgoing request body

### DIFF
--- a/src/server/middlewares/proxy.ts
+++ b/src/server/middlewares/proxy.ts
@@ -14,6 +14,18 @@ export const registerProxyRoutes = (app: express.Application) => {
         pathRewrite: { [route.path]: route.targetPath },
         changeOrigin: true,
         headers: { "X-API-KEY": apiKey },
+        logLevel: "debug",
+        onProxyReq(proxyReq, req) {
+          // https://github.com/chimurai/http-proxy-middleware/issues/202#issuecomment-440562619
+          if (req.body) {
+            const bodyData = JSON.stringify(req.body);
+
+            proxyReq.setHeader("Content-Type", "application/json");
+            proxyReq.setHeader("Content-Length", Buffer.byteLength(bodyData));
+
+            proxyReq.write(bodyData);
+          }
+        },
       })
     );
   });


### PR DESCRIPTION
La request que enviaba la API Gateway hacia fuera no tenía bien el body (no he podido obtener más información debugueando). Este fix está sacado de un issue que he linkado en un comentario.