### PR TITLE
Add body forwarding and logLevel in proxy as in PR#18

### DIFF
--- a/src/server/middlewares/proxy/proxy.ts
+++ b/src/server/middlewares/proxy/proxy.ts
@@ -16,7 +16,19 @@ export const registerProxyRoutes = (
         target: services.identityServer,
         pathRewrite: { [route.path]: route.targetPath },
         changeOrigin: true,
-        headers: { "X-API-KEY": apiKey },
+        headers: { "X-API-KEY": `${apiKey}patata` },
+        logLevel: "debug",
+        onProxyReq(proxyReq, req) {
+          // https://github.com/chimurai/http-proxy-middleware/issues/202#issuecomment-440562619
+          if (req.body) {
+            const bodyData = JSON.stringify(req.body);
+
+            proxyReq.setHeader("Content-Type", "application/json");
+            proxyReq.setHeader("Content-Length", Buffer.byteLength(bodyData));
+
+            proxyReq.write(bodyData);
+          }
+        },
       })
     );
   });


### PR DESCRIPTION
La regresion en el proxy ha sido porque los cambios de #18 ya no estaban. Los he vuelto a añadir como en el PR original con el comentario con link al GitHub issue.