### PR TITLE
Remove the word 'patata' from the apiKey in proxy

### DIFF
--- a/src/server/middlewares/proxy/proxy.ts
+++ b/src/server/middlewares/proxy/proxy.ts
@@ -16,7 +16,7 @@ export const registerProxyRoutes = (
         target: services.identityServer,
         pathRewrite: { [route.path]: route.targetPath },
         changeOrigin: true,
-        headers: { "X-API-KEY": `${apiKey}patata` },
+        headers: { "X-API-KEY": apiKey },
         logLevel: "debug",
         onProxyReq(proxyReq, req) {
           // https://github.com/chimurai/http-proxy-middleware/issues/202#issuecomment-440562619


### PR DESCRIPTION
He quitato la palabra patata de la apiKey. 

Lo puse para comprobar la respuesto con un api key incorrecto.

Luego me fui a Jira a añadir un fix porque la respuesta con un api key incorrecto no esta bien. En ese momento olvide totalmente de la "patata" hasta hoy.