### PR TITLE
Add npm i when there are diff in HEAD and always exit 0 post-merge

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,10 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-git diff HEAD~ HEAD --name-only | grep -E '^(package-lock\.json|yarn\.lock)$'
+if git diff HEAD~ HEAD --name-only | grep -E '^(package-lock\.json|yarn\.lock)$';
+then 
+    npm i
+    echo -e "Detected changes in dependencies, executing npm install..." 
+fi
+
+exit 0


### PR DESCRIPTION
Le faltaba añadir un if para comprobar si había diferencias respecto el head, un then para instalar las dependencias, el fi es para acabar.
Y siempre en todos los casos va a salir con un exit 0 para que no genere errores.