### PR TITLE
First echo message and then install dependencies in post-merge hook

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -3,8 +3,8 @@
 
 if git diff HEAD~ HEAD --name-only | grep -E '^(package-lock\.json|yarn\.lock)$';
 then 
-    npm i
     echo -e "Detected changes in dependencies, executing npm install..." 
+    npm i
 fi
 
 exit 0


### PR DESCRIPTION
Cambiado el orden del mensaje del echo previo a lanzar el comando de npm i en el post-merge hook