### PR TITLE
Add setHeaderCredentials middleware to allow acces to credentials

### DIFF
--- a/src/constants/requestHeaders.ts
+++ b/src/constants/requestHeaders.ts
@@ -3,6 +3,7 @@ const requestHeaders = {
   apiName: "X-API-NAME",
   contentType: "Content-Type",
   contentLength: "Content-Length",
+  allowCredentials: "Access-Control-Allow-Credentials",
 };
 
 export default requestHeaders;

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -11,8 +11,11 @@ import { environment } from "../loadEnvironments.js";
 import { registerProxyRoutes } from "./middlewares/proxy/proxy.js";
 import proxyRoutes from "./routers/proxy/proxyRoutes.js";
 import { paths } from "./routers/paths.js";
+import setHeaderCredentials from "./middlewares/setHeaderCredentials/setHeaderCredentials.js";
 
 const app = express();
+
+app.use(setHeaderCredentials);
 
 app.use(cors(corsOptions));
 app.disable("x-powered-by");

--- a/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.test.ts
+++ b/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.test.ts
@@ -1,0 +1,23 @@
+import type { Request, Response, NextFunction } from "express";
+import requestHeaders from "../../../constants/requestHeaders";
+import setHeaderCredentials from "./setHeaderCredentials";
+
+const { allowCredentials } = requestHeaders;
+
+describe("Given a setHeaderCredentials middleware", () => {
+  describe("When it receives a request, response and next function", () => {
+    test("Then it should invoke response's method header with 'Access-Control-Allow-Credentials', 'true' and next function", () => {
+      const req: Partial<Request> = {};
+      const res: Partial<Response> = {
+        header: jest.fn(),
+      };
+
+      const next: NextFunction = jest.fn();
+
+      setHeaderCredentials(req as Request, res as Response, next);
+
+      expect(res.header).toHaveBeenCalledWith(allowCredentials, "true");
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.test.ts
+++ b/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.test.ts
@@ -4,19 +4,28 @@ import setHeaderCredentials from "./setHeaderCredentials";
 
 const { allowCredentials } = requestHeaders;
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 describe("Given a setHeaderCredentials middleware", () => {
-  describe("When it receives a request, response and next function", () => {
-    test("Then it should invoke response's method header with 'Access-Control-Allow-Credentials', 'true' and next function", () => {
-      const req: Partial<Request> = {};
-      const res: Partial<Response> = {
-        header: jest.fn(),
-      };
+  const req: Partial<Request> = {};
+  const res: Partial<Response> = {
+    header: jest.fn(),
+  };
 
-      const next: NextFunction = jest.fn();
+  const next: NextFunction = jest.fn();
 
+  describe("When it receives a response and next function", () => {
+    test("Then it should invoke response's method header with 'Access-Control-Allow-Credentials', 'true'", () => {
       setHeaderCredentials(req as Request, res as Response, next);
 
       expect(res.header).toHaveBeenCalledWith(allowCredentials, "true");
+    });
+
+    test("Then it should invoke next function", () => {
+      setHeaderCredentials(req as Request, res as Response, next);
+
       expect(next).toHaveBeenCalled();
     });
   });

--- a/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.ts
+++ b/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
-import requestHeaders from "../../../constants/requestHeaders";
+import requestHeaders from "../../../constants/requestHeaders.js";
 
 const { allowCredentials } = requestHeaders;
 

--- a/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.ts
+++ b/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.ts
@@ -1,0 +1,16 @@
+import type { Request, Response, NextFunction } from "express";
+import requestHeaders from "../../../constants/requestHeaders";
+
+const { allowCredentials } = requestHeaders;
+
+const setHeaderCredentials = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  res.header(allowCredentials, "true");
+
+  next();
+};
+
+export default setHeaderCredentials;


### PR DESCRIPTION
Añadido el mismo middleware que identity-server para setear las header credentials a true en las peticiones. PR  81 identity-server: https://github.com/coders-app/coders-app-identity-server/pull/81